### PR TITLE
feat: auto import components

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,13 @@ import App from './App.vue'
 
 const app = createApp(App)
 
+const files = require.context('./', true, /\.vue$/i)
+files
+  .keys()
+  .map(key =>
+    app.component(key.split('/').pop().split('.')[0], files(key).default)
+  )
+
 let routes = []
 
 const pageFiles = require.context('./pages/', true, /\.(vue|js)$/i)


### PR DESCRIPTION
# Description

This feature allows to use Vue components just by creating a `.vue` file on the `src/component` folder. No need for component imports anymore.